### PR TITLE
Replace usage of package gnorm with {{$rootPkg}}

### DIFF
--- a/generated/public/authors/authors.go
+++ b/generated/public/authors/authors.go
@@ -51,7 +51,7 @@ func All(ctx context.Context, db generated.DB) ([]*Row, error) {
 }
 
 // CountQuery retrieve one row from 'authors'.
-func CountQuery(ctx context.Context, db gnorm.DB, where gnorm.WhereClause) (int, error) {
+func CountQuery(ctx context.Context, db generated.DB, where generated.WhereClause) (int, error) {
 	const origsqlstr = `SELECT
 		count(*) as count
 		FROM public.authors WHERE (`
@@ -197,7 +197,7 @@ func Insert(ctx context.Context, db generated.DB, r *Row) error {
 }
 
 // InsertIgnore inserts the row into the database but ignores conflicts
-func InsertIgnore(ctx context.Context, db gnorm.DB, r *Row, constraint string) error {
+func InsertIgnore(ctx context.Context, db generated.DB, r *Row, constraint string) error {
 	sqlstr := `INSERT INTO public.authors ` +
 		`(
 			name

--- a/generated/public/books/books.go
+++ b/generated/public/books/books.go
@@ -72,7 +72,7 @@ func All(ctx context.Context, db generated.DB) ([]*Row, error) {
 }
 
 // CountQuery retrieve one row from 'books'.
-func CountQuery(ctx context.Context, db gnorm.DB, where gnorm.WhereClause) (int, error) {
+func CountQuery(ctx context.Context, db generated.DB, where generated.WhereClause) (int, error) {
 	const origsqlstr = `SELECT
 		count(*) as count
 		FROM public.books WHERE (`
@@ -261,7 +261,7 @@ func Insert(ctx context.Context, db generated.DB, r *Row) error {
 }
 
 // InsertIgnore inserts the row into the database but ignores conflicts
-func InsertIgnore(ctx context.Context, db gnorm.DB, r *Row, constraint string) error {
+func InsertIgnore(ctx context.Context, db generated.DB, r *Row, constraint string) error {
 	sqlstr := `INSERT INTO public.books ` +
 		`(
 			author_id, available, booktype, isbn, pages, summary, title

--- a/gnorm_templates/table.gotmpl
+++ b/gnorm_templates/table.gotmpl
@@ -67,7 +67,7 @@ func All(ctx context.Context, db {{$rootPkg}}.DB) ([]*Row, error) {
 }
 
 // CountQuery retrieve one row from '{{ $table }}'.
-func CountQuery(ctx context.Context, db gnorm.DB, where gnorm.WhereClause) (int, error) {
+func CountQuery(ctx context.Context, db {{$rootPkg}}.DB, where {{$rootPkg}}.WhereClause) (int, error) {
 	const origsqlstr = `SELECT
 		count(*) as count
 		FROM {{$schema}}.{{ $table }} WHERE (`
@@ -278,7 +278,7 @@ func Update(ctx context.Context, db {{$rootPkg}}.DB, r *Row) error {
 {{end}}
 
 // InsertIgnore inserts the row into the database but ignores conflicts
-func InsertIgnore(ctx context.Context, db gnorm.DB, r *Row, constraint string) error {
+func InsertIgnore(ctx context.Context, db {{$rootPkg}}.DB, r *Row, constraint string) error {
 	sqlstr := `INSERT INTO {{$schema}}.{{ $table }} ` +
 		{{- if gt (len $insertCols) 0}}
 		`(


### PR DESCRIPTION
Looks like these were accidentally left unchanged. `goimports` will automatically pick these up and for me it defaults to importing the gnorm mysql driver which causes issues.